### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,14 @@ Based on research from
 ## Usage
 
 ```go
-import "github.com/grassmudhorses/vader-go/sentitext"
+	
+
+import (
+    "github.com/grassmudhorses/vader-go/lexicon"
+    "github.com/grassmudhorses/vader-go/sentitext"
+)
 ...
-vader := sentitext.PolarityScore("Hello World 💕 I Love the World!")
+vader := sentitext.PolarityScore(sentitext.Parse("Hello World 💕 I Love the World!", lexicon.DefaultLexicon))
 ```
 ## Development
 


### PR DESCRIPTION
fix example

Original example as given does not build:

```
./main_test.go:18:35: cannot use "Hello World 💕 I Love the World!" (untyped string constant) as *sentitext.SentiText value in argument to sentitext.PolarityScore
```